### PR TITLE
Add evolution logic and update UI theme for sliders

### DIFF
--- a/Resource/Theme/Default.tres
+++ b/Resource/Theme/Default.tres
@@ -1,4 +1,9 @@
-[gd_resource type="Theme" load_steps=7 format=3 uid="uid://csfdjcxm263dk"]
+[gd_resource type="Theme" load_steps=12 format=3 uid="uid://csfdjcxm263dk"]
+
+[ext_resource type="Texture2D" uid="uid://ft3dph6xdfey" path="res://Asset/Cookie/cookie 16x16.png" id="1_fllre"]
+[ext_resource type="Texture2D" uid="uid://dcgkvpvt3y0h7" path="res://Asset/UI/meter base.png" id="2_fllre"]
+[ext_resource type="Texture2D" uid="uid://bbjpo7g4a606e" path="res://Asset/UI/light green bar.png" id="2_nu8xn"]
+[ext_resource type="StyleBox" uid="uid://bhycxstgq217k" path="res://new_style_box_texture.tres" id="3_r5mtt"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8tqug"]
 bg_color = Color(0.227882, 0.247012, 1.20327e-07, 1)
@@ -48,6 +53,13 @@ corner_radius_top_right = 10
 corner_radius_bottom_right = 10
 corner_radius_bottom_left = 10
 
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_prt2e"]
+texture = ExtResource("2_nu8xn")
+texture_margin_left = 5.0
+texture_margin_top = 5.0
+texture_margin_right = 5.0
+texture_margin_bottom = 5.0
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1x16r"]
 bg_color = Color(0.933333, 0.858824, 0.784314, 1)
 border_width_left = 4
@@ -85,11 +97,18 @@ Button/colors/font_outline_color = Color(0.227882, 0.247012, 1.20327e-07, 1)
 Button/colors/font_pressed_color = Color(0.592157, 0.701961, 0.305882, 1)
 Button/constants/align_to_largest_stylebox = 1
 Button/constants/outline_size = 10
-Button/font_sizes/font_size = 37
+Button/font_sizes/font_size = 35
 Button/styles/focus = SubResource("StyleBoxFlat_8tqug")
 Button/styles/hover = SubResource("StyleBoxFlat_6bllo")
 Button/styles/normal = SubResource("StyleBoxFlat_73axr")
 Button/styles/pressed = SubResource("StyleBoxFlat_k0s2m")
+HSlider/icons/grabber = ExtResource("1_fllre")
+HSlider/icons/grabber_disabled = ExtResource("1_fllre")
+HSlider/icons/grabber_highlight = ExtResource("1_fllre")
+HSlider/icons/tick = ExtResource("2_fllre")
+HSlider/styles/grabber_area = ExtResource("3_r5mtt")
+HSlider/styles/grabber_area_highlight = ExtResource("3_r5mtt")
+HSlider/styles/slider = SubResource("StyleBoxTexture_prt2e")
 ProgressBar/colors/font_color = Color(0.592157, 0.701961, 0.305882, 1)
 ProgressBar/colors/font_outline_color = Color(0.227882, 0.247012, 1.20327e-07, 1)
 ProgressBar/constants/outline_size = 4

--- a/Scene/SceneManager.tscn
+++ b/Scene/SceneManager.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=3 uid="uid://cn5lx5caavnr7"]
+[gd_scene load_steps=29 format=3 uid="uid://cn5lx5caavnr7"]
 
 [ext_resource type="Script" uid="uid://dmuifn515spf3" path="res://Script/World/world.gd" id="1_75dai"]
 [ext_resource type="Script" uid="uid://b6olpgnblqb85" path="res://Script/World/Utl/scene_manager.gd" id="1_wi563"]
@@ -38,6 +38,8 @@ outline_size = 2
 outline_color = Color(0, 0, 0, 1)
 shadow_size = 3
 shadow_color = Color(0, 0, 0, 0.639216)
+
+[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_umu00"]
 
 [node name="SceneManager" type="Node"]
 script = ExtResource("1_wi563")
@@ -250,7 +252,6 @@ expand_icon = true
 script = ExtResource("20_j16kb")
 
 [node name="TitleScreen" type="PanelContainer" parent="Container/GUI"]
-visible = false
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -270,12 +271,13 @@ horizontal_alignment = 1
 
 [node name="Button" type="Button" parent="Container/GUI/TitleScreen/Title"]
 layout_mode = 2
-offset_left = 235.0
-offset_top = 33.0
-offset_right = 273.0
-offset_bottom = 56.0
+offset_left = 211.0
+offset_top = 39.0
+offset_right = 287.0
+offset_bottom = 83.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
+theme = ExtResource("13_k3mqv")
 text = "Start"
 
 [node name="MenuScreen" type="PanelContainer" parent="Container/GUI"]
@@ -299,10 +301,17 @@ columns = 3
 
 [node name="Sound" type="Button" parent="Container/GUI/MenuScreen/GridContainer"]
 layout_mode = 2
+theme = ExtResource("13_k3mqv")
+theme_override_constants/outline_size = 8
+theme_override_font_sizes/font_size = 25
 text = "Sound"
 
 [node name="Back" type="Button" parent="Container/GUI/MenuScreen/GridContainer"]
 layout_mode = 2
+size_flags_stretch_ratio = 3.83
+theme = ExtResource("13_k3mqv")
+theme_override_constants/outline_size = 8
+theme_override_font_sizes/font_size = 25
 text = "Back
 "
 
@@ -311,38 +320,54 @@ layer = 10
 visible = false
 script = ExtResource("24_umu00")
 
-[node name="BackgroundColor2" type="ColorRect" parent="Container/GUI/MenuScreen/SoundMenu"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+[node name="BackgroundColor2" type="TextureRect" parent="Container/GUI/MenuScreen/SoundMenu"]
+material = SubResource("CanvasItemMaterial_umu00")
+anchors_preset = -1
+anchor_left = 0.104
+anchor_top = 0.134
+anchor_right = 0.914
+anchor_bottom = 0.766
+offset_left = -1.248
+offset_top = 8.968
+offset_right = -0.968018
+offset_bottom = 15.832
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.105517, 0.101088, 0.00166336, 1)
+texture = ExtResource("8_b6n0h")
 
-[node name="Volume" type="HSlider" parent="Container/GUI/MenuScreen/SoundMenu"]
+[node name="Volume" type="HSlider" parent="Container/GUI/MenuScreen/SoundMenu/BackgroundColor2"]
+layout_mode = 1
 anchors_preset = 14
 anchor_top = 0.5
 anchor_right = 1.0
 anchor_bottom = 0.5
-offset_left = 1.0
-offset_top = -8.0
-offset_right = 1.0
-offset_bottom = 8.0
+offset_top = 5.0
+offset_bottom = 21.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("13_k3mqv")
 min_value = -20.0
 max_value = 15.0
 tick_count = 1
 ticks_on_borders = true
 
-[node name="Label" type="Label" parent="Container/GUI/MenuScreen/SoundMenu"]
-offset_left = 244.0
-offset_top = 201.0
-offset_right = 284.0
-offset_bottom = 216.0
+[node name="Label" type="Label" parent="Container/GUI/MenuScreen/SoundMenu/BackgroundColor2"]
+layout_mode = 0
+offset_left = 192.0
+offset_top = 132.0
+offset_right = 233.0
+offset_bottom = 147.0
+theme = ExtResource("13_k3mqv")
 text = "Volume"
 
-[node name="Back" type="Button" parent="Container/GUI/MenuScreen/SoundMenu"]
+[node name="Back" type="Button" parent="Container/GUI/MenuScreen/SoundMenu/BackgroundColor2"]
+layout_mode = 0
+offset_left = 342.0
+offset_top = 245.0
+offset_right = 414.0
+offset_bottom = 290.0
+theme = ExtResource("13_k3mqv")
+theme_override_font_sizes/font_size = 25
 text = "Back"
 
 [node name="GuiSfx" type="AudioStreamPlayer" parent="."]
@@ -357,5 +382,5 @@ script = ExtResource("22_j16kb")
 [connection signal="pressed" from="Container/GUI/TitleScreen/Title/Button" to="Container/GUI/TitleScreen" method="_on_button_pressed"]
 [connection signal="pressed" from="Container/GUI/MenuScreen/GridContainer/Sound" to="Container/GUI/MenuScreen" method="_on_sound_pressed"]
 [connection signal="pressed" from="Container/GUI/MenuScreen/GridContainer/Back" to="Container/GUI/MenuScreen" method="_on_back_pressed"]
-[connection signal="value_changed" from="Container/GUI/MenuScreen/SoundMenu/Volume" to="BGM" method="_on_volume_value_changed"]
-[connection signal="pressed" from="Container/GUI/MenuScreen/SoundMenu/Back" to="Container/GUI/MenuScreen/SoundMenu" method="_on_back_pressed"]
+[connection signal="value_changed" from="Container/GUI/MenuScreen/SoundMenu/BackgroundColor2/Volume" to="BGM" method="_on_volume_value_changed"]
+[connection signal="pressed" from="Container/GUI/MenuScreen/SoundMenu/BackgroundColor2/Back" to="Container/GUI/MenuScreen/SoundMenu" method="_on_back_pressed"]

--- a/Script/Autoload/events.gd
+++ b/Script/Autoload/events.gd
@@ -16,6 +16,7 @@ const THRESHOLD := 0.7
 ## If you still need this elsewhere, keep it
 var event_list: Dictionary[String, float] = {}
 
+
 ## Track the last band for each individual stat
 var _band_last := {
 	"happiness": -1,
@@ -31,9 +32,15 @@ func _anim_for_level(stat_name: String, value: float) -> String:
 	var sfx  : int
 
 	if value > 0.9:
+		
 		band = 3
 		anim = "Happy"
 		sfx  = SFX.Track.CHIRP
+		if stat_name == "happiness":
+			Globals.mothlyn_points = Globals.mothlyn_points + 1
+		if stat_name == "hunger":
+			Globals.gigazilla_points = Globals.gigazilla_points + 1
+		
 	elif value > 0.5:
 		band = 2
 		anim = "Idle"
@@ -52,7 +59,9 @@ func _anim_for_level(stat_name: String, value: float) -> String:
 		_band_last[stat_name] = band
 		emit_signal("play_sfx_signal", sfx)
 		print("SFX:", anim, "for", stat_name)
+	
 
+	
 	return anim
 
 

--- a/Script/Autoload/globals.gd
+++ b/Script/Autoload/globals.gd
@@ -47,6 +47,11 @@ var current_hygiene   : float     : set = set_current_hygiene,   get = get_curre
 var current_game_state: GameState : set = set_game_state,        get = get_game_state
 ## Active macro-state (GUI, MAIN play, etc.).
 
+
+var gigazilla_points: float
+var mothlyn_points: int
+
+
 ## At ready
 func _ready() -> void:
 	### Called once when the singleton is initialised.

--- a/Script/GUI/title_screen.gd
+++ b/Script/GUI/title_screen.gd
@@ -4,4 +4,3 @@ class_name TitleScreen extends PanelContainer
 
 func _on_button_pressed() -> void: ## When button is pressed, triggers this function to turn Title Screen off. 
 	set_visible(false)
-	Events.change_bgm()

--- a/Script/Mob/base_body.gd
+++ b/Script/Mob/base_body.gd
@@ -97,6 +97,7 @@ func _on_evolution(stage:int)->void:
 			await base_body_sprite.set_stage(base_body_sprite.Stage.HATCHLING)
 			
 		2:
+			_check_ev_line()
 			if !_is_godzilla:
 				base_body_sprite.set_stage(base_body_sprite.Stage.JUV_MOTH)
 				print(_is_godzilla, "mothy")
@@ -109,3 +110,7 @@ func _on_evolution(stage:int)->void:
 			else:
 				base_body_sprite.set_stage(base_body_sprite.Stage.ADULT_GIGA)
 	ev_visual_effect.play()
+
+func _check_ev_line():
+	if Globals.gigazilla_points > Globals.mothlyn_points:
+		_is_godzilla = true

--- a/new_style_box_texture.tres
+++ b/new_style_box_texture.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxTexture" load_steps=2 format=3 uid="uid://bhycxstgq217k"]
+
+[ext_resource type="Texture2D" uid="uid://ly7jjl4i0rfg" path="res://Asset/UI/meter base (1).png" id="1_5slsn"]
+
+[resource]
+texture = ExtResource("1_5slsn")
+texture_margin_left = 1.0
+texture_margin_top = 1.0
+texture_margin_right = 1.0
+texture_margin_bottom = 1.0


### PR DESCRIPTION
Introduces gigazilla_points and mothlyn_points to track evolution paths and updates evolution logic in base_body.gd to select the path based on these points. Enhances the Default theme and SceneManager to style HSlider and related UI elements, adds a new StyleBoxTexture resource, and refactors the sound menu layout. Also removes an unnecessary BGM change call from the title screen.